### PR TITLE
update for meteor 0.9

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -2,7 +2,7 @@ var sourceHandler = function (compileStep) {
 
   // XXX Code copied from
   // packages/templating/plugin/compile-template.js:6
-  if (! compileStep.arch.match(/^browser(\.|$)/))
+  if (! compileStep.arch.match(/^web.browser(\.|$)/))
     return;
 
   // Parse and compile the content


### PR DESCRIPTION
This update is to make it compatible with meteor 0.9. To publish to the new package system, we need to modify the `package.js` and `smart.json`. I'm not sure what you developer account is, so I didn't include that part in this pull request. You can reference my fork https://github.com/waitingkuo/meteor-jade . I've also released it as a temporary solution, you can try it by `meteor add waitingkuo:meteor-jade`

Also, this pull request is relative to #58 and #63
