### PR TITLE
Remove coma in the Spacebar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ Like with Spacebars, a component can receive both ordered and keywords
 arguments. Keywords arguments must be written after the ordered ones:
 
 ```
-+myComponent(arg1, arg2, arg3, key1=val1, key2=val2)
++myComponent(arg1 arg2 arg3 key1=val1 key2=val2)
 ```
 
 Brackets are optional:
 
 ```
-+myComponent arg1, arg2, arg3, key1=val1, key2=val2
++myComponent arg1 arg2 arg3 key1=val1 key2=val2
 ```
 
 For the four build-in components (`if`, `unless`, `each` and `with`) the `+`


### PR DESCRIPTION
Examples of Spacebar component's call shows coma between attributes. This makes Jade having compilation errors.
