### PR TITLE
allow use on server (as a package and not just buildPlugin)

### DIFF
--- a/package.js
+++ b/package.js
@@ -24,6 +24,18 @@ Package.registerBuildPlugin({
   }
 });
 
+Npm.depends({
+  "jade": "https://github.com/mquandalle/jade/tarball/f3f956fa1031e05f85be7bc7b67f12e9ec80ba37"
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom("METEOR@0.9.0");
+  api.use(['underscore','htmljs','html-tools','spacebars-compiler'], 'server');
+  api.addFiles(['plugin/lexer.js','plugin/parser.js','plugin/compiler.js'], 'server');
+  api.addFiles('server/jadeServer.js', 'server');
+  api.export('jade', 'server');
+});
+
 Package.onTest(function (api) {
   api.versionsFrom("METEOR@0.9.0");
   api.use("tinytest");

--- a/server/jadeServer.js
+++ b/server/jadeServer.js
@@ -1,0 +1,16 @@
+jade = {
+  compile: function(content, filename) {
+    if (!filename)
+      filename='(content)';
+
+    try {
+      var parser = new Parser(content, filename, { lexer: Lexer });
+      var results = new Compiler(parser.parse()).compile();
+    } catch (err) {
+      // TODO, something smart :)
+      throw err;
+    }
+
+    return results;
+  }
+};


### PR DESCRIPTION
Hey, this is maybe more for discussion than a merge-as-is.  I need to compile "meteor jade" (i.e. jade with components, via your package) on the server (and actually [on the client](https://github.com/gadicc/meteor-jade-client) too, but that's another matter).

This PR is a starting point that allows for that, but points to consider:
1. Currently, only `jade.compile()` is provided (it's all I needed).  What else?  We should also allow direct access to the npm package, I think.
2. Where to place server package stuff?  I did `server/jadeServer.js`, but not sure what your preferences are for this.  `lib/something.js` ?  In the root?  Not sure about your preferences here.  Just one file for now but could potentially be more in the future.
