### PR TITLE
Rewrite $ attributes directly to dynamic attributes

### DIFF
--- a/packages/jade-compiler/lib/transpilers.js
+++ b/packages/jade-compiler/lib/transpilers.js
@@ -351,6 +351,14 @@ _.extend(TemplateCompiler.prototype, {
     };
     var dynamicAttrs = [];
 
+    // Rewrite $ attributes directly to dynamic attributes
+    _.each(attrs, function (attr) {
+      if (attr.name.charAt(0) === "$" && attr.name !== "$dyn") {
+        attr.val = attr.name.slice(1) + " " + attr.val;
+        attr.name = "$dyn";
+      }
+    });
+
     _.each(attrs, function (attr) {
       var val = attr.val;
       var key = attr.name;

--- a/packages/jade-compiler/lib/transpilers.js
+++ b/packages/jade-compiler/lib/transpilers.js
@@ -351,15 +351,13 @@ _.extend(TemplateCompiler.prototype, {
     };
     var dynamicAttrs = [];
 
-    // Rewrite $ attributes directly to dynamic attributes
     _.each(attrs, function (attr) {
+      // Rewrite $ attributes directly to dynamic attributes
       if (attr.name.charAt(0) === "$" && attr.name !== "$dyn") {
         attr.val = attr.name.slice(1) + " " + attr.val;
         attr.name = "$dyn";
       }
-    });
 
-    _.each(attrs, function (attr) {
       var val = attr.val;
       var key = attr.name;
 


### PR DESCRIPTION
Replaces my previous pull request [#165](https://github.com/mquandalle/meteor-jade/pull/165) – moved the code to a different git branch.

Comment on old pull request:
<br>
---

I believe this would be a powerful addition to `mquandalle:jade`. It might look bigger than it actually is – this feature is fully backwards compatible, since attributes beginning with dollar sign have not been allowed previously.

The idea is to use the name of the `$` attribute directly as the name of a dynamic attribute helper (sans the dollar sign).

My personal use case is to clean up the bindings in [dalgard:viewmodel](https://github.com/dalgard/meteor-viewmodel/), but it could be used for anything.

This code:

```jade
input($bind='value: value')  //- any attribute name beginning with $
```

... simply translates to:

```html
<input {{bind 'value: value'}}>
```

Without the feature, people are forced to use this clunky syntax:

```jade
input($dyn='{{bind "value: value"}}')
```