### PR TITLE
Remove new lines in generated javascript

### DIFF
--- a/packages/jade/plugin/handler.js
+++ b/packages/jade/plugin/handler.js
@@ -93,6 +93,8 @@ class JadeCompilerPlugin extends CachingCompiler {
       jsContent += _.map(results.templates, this._templateGen).join("");
     }
 
+    jsContent = jsContent.replace(/\\n/g, "");
+
     if (jsContent !== "") {
       file.addJavaScript({
         path: file.getPathInPackage() + '.js',
@@ -119,6 +121,8 @@ class JadeCompilerPlugin extends CachingCompiler {
       } else {
         jsContent = this._templateGen(result, templateName);
       }
+
+      jsContent = jsContent.replace(/\\n/g, "");
 
       file.addJavaScript({
         path: file.getPathInPackage() + '.js',


### PR DESCRIPTION
I was able to get `inline-block` styling working by just removing new lines from the compiled javascript. Any thoughts on this? Thanks!