### PR TITLE
helper parameters (#153 #147)

### DIFF
--- a/packages/jade-compiler/lib/lexer.js
+++ b/packages/jade-compiler/lib/lexer.js
@@ -62,12 +62,11 @@ var attrs = Lexer.prototype.attrs;
 Lexer.prototype.attrs = function (push) {
   if (this.input.charAt(0) === "(") {
     var range = this.bracketExpression(),
-        attrs_str = this.input.slice(range.start, range.end),
-        regex = /(!?[$=])((?:\.{1,2}\/)?[\w\.-]+)\(((?:(['"])\4|(['"]).*?[^\\]\5|[^)]*[^\\](['"])\6|[^)]*?[^\\](['"]).*[^\\]\7)*[^)]*?)\)/g;
+      attrs_str = this.input.slice(range.start, range.end),
+      regex = /(!?[$=])((?:\.{1,2}\/)?[\w\.-]+)\(((?:(['"])\4|(['"]).*?[^\\]\5|[^)]*[^\\](['"])\6|[^)]*?[^\\](['"]).*[^\\]\7)*[^)]*?)\)/g;
 
     attrs_str = attrs_str.replace(regex, function (match, prefix, helper, args) {
-      var begin = (prefix === "$" ? "$dyn='" : (prefix === "!=" ? "!='{" : "='")) + "{{",
-          end = "}}" + (prefix === "!=" ? "}'" : "'");
+      var begin = (prefix === "$" ? "$dyn='" : (prefix === "!=" ? "!='{" : "='")) + "{{", end = "}}" + (prefix === "!=" ? "}'" : "'");
 
       return begin + helper + " " + args.replace(/(^|[^\\])'/g, "$1\\'") + end;
     });

--- a/packages/jade-compiler/lib/lexer.js
+++ b/packages/jade-compiler/lib/lexer.js
@@ -55,6 +55,29 @@ Lexer.prototype.userComponents = function () {
   }
 };
 
+// Super method
+var attrs = Lexer.prototype.attrs;
+
+// Make attributes accept Blaze helper expressions inside parentheses
+Lexer.prototype.attrs = function (push) {
+  if (this.input.charAt(0) === "(") {
+    var range = this.bracketExpression(),
+        attrs_str = this.input.slice(range.start, range.end),
+        regex = /(!?[$=])((?:\.{1,2}\/)?[\w\.-]+)\(((?:(['"])\4|(['"]).*?[^\\]\5|[^)]*[^\\](['"])\6|[^)]*?[^\\](['"]).*[^\\]\7)*[^)]*?)\)/g;
+
+    attrs_str = attrs_str.replace(regex, function (match, prefix, helper, args) {
+      var begin = (prefix === "$" ? "$dyn='" : (prefix === "!=" ? "!='{" : "='")) + "{{",
+          end = "}}" + (prefix === "!=" ? "}'" : "'");
+
+      return begin + helper + " " + args.replace(/(^|[^\\])'/g, "$1\\'") + end;
+    });
+
+    this.input = "(" + attrs_str + this.input.slice(range.end);
+  }
+
+  return attrs.call(this, push);
+};
+
 // Register the two rules above
 var _super = Lexer.prototype.next;
 Lexer.prototype.next = function () {

--- a/packages/jade-compiler/lib/transpilers.js
+++ b/packages/jade-compiler/lib/transpilers.js
@@ -295,8 +295,18 @@ _.extend(TemplateCompiler.prototype, {
     // syntaxes. So let's do it.
     // Since we rely on the Spacebars parser for this, we support the
     // {{mustache}} and {{{unescapedMustache}}} syntaxes as well.
-    text = text.replace(/#\{\s*((\.{1,2}\/)*[\w\.-]+)\s*\}/g, "{{$1}}");
-    text = text.replace(/!\{\s*((\.{1,2}\/)*[\w\.-]+)\s*\}/g, "{{{$1}}}");
+    // We capture everything until the closing curly brace. We do not want to
+    // match a closing curly brace if we are inside a string literal, i.e.
+    // inside non-escaped single or double quotes.
+    var regex = /([#!])\{([^}]*?(?:[^\\](['"]).*?[^\\]\3[^}]*?)*)\}/g;
+
+    text = text.replace(regex, function (match, prefix, expression) {
+      var begin = (prefix === "!" ? "{{{" : "{{"),
+          end = (prefix === "!" ? "}}}" : "}}"),
+          paren_re = /((?:\.{1,2}\/)?[\w\.-]+)\((.*)\)$/g;  // Allow #{helper(args)} syntax
+
+      return begin + expression.replace(paren_re, "$1 $2") + end;
+    });
 
     options = options || {};
     options.getTemplateTag = SpacebarsCompiler.TemplateTag.parseCompleteTag;

--- a/packages/jade-compiler/lib/transpilers.js
+++ b/packages/jade-compiler/lib/transpilers.js
@@ -302,8 +302,8 @@ _.extend(TemplateCompiler.prototype, {
 
     text = text.replace(regex, function (match, prefix, expression) {
       var begin = (prefix === "!" ? "{{{" : "{{"),
-          end = (prefix === "!" ? "}}}" : "}}"),
-          paren_re = /((?:\.{1,2}\/)?[\w\.-]+)\((.*)\)$/g;  // Allow #{helper(args)} syntax
+        end = (prefix === "!" ? "}}}" : "}}"),
+        paren_re = /((?:\.{1,2}\/)?[\w\.-]+)\((.*)\)$/g;  // Allow #{helper(args)} syntax
 
       return begin + expression.replace(paren_re, "$1 $2") + end;
     });
@@ -450,8 +450,6 @@ _.extend(TemplateCompiler.prototype, {
       content = self._optimize(content[0]);
     else if (interposeEOL)
       content = self._interposeEOL(content);
-    else
-      content = content;
 
     return self._removeNewLinePrefixes(content);
   }

--- a/packages/jade-compiler/tests/tests.js
+++ b/packages/jade-compiler/tests/tests.js
@@ -30,3 +30,15 @@ Tinytest.add("JadeCompiler - compile templates", function(test) {
   test.equal(JadeCompiler.compile(template),
   "(function() {\n  return HTML.P(\"hello world\");\n})");
 });
+
+Tinytest.add("JadeCompiler - compile template with parameters in helper", function(test) {
+  var template = 'p #{foo (foo "bar")}';
+  test.equal(JadeCompiler.compile(template),
+  "(function() {\n  return HTML.P(Blaze.View(\"lookup:foo\", function() {\n    return Spacebars.mustache(view.lookup(\"foo\"), Spacebars.dataMustache(view.lookup(\"foo\"), \"bar\"));\n  }));\n})");
+});
+
+Tinytest.add("JadeCompiler - compile template with parameters in helper on attribute", function(test) {
+  var template = "p(title=foo('bar'))";
+  test.equal(JadeCompiler.compile(template),
+  "(function() {\n  return HTML.P({\n    title: function() {\n      return Spacebars.mustache(view.lookup(\"foo\"), \"bar\");\n    }\n  });\n})");
+});


### PR DESCRIPTION
Hi,

I was really looking forward to using helpers with some arguments, but would rather not return to the {{}} syntax to do so.

So, I took a look at @dalgard 's [fork](https://github.com/dalgard/meteor-jade) which allows for helper parameters. Sadly, the fork seems to be a bit stale (something around 30 commits behind @mquandalle 's master).

I know merging the whole thing may be complex or take too long, so I manually took the source regarding helper parameters to make this PR. Basically, it allows for the use of simple arguments on the templates so a piece of code like this would work:

``` javascript
Template.subjects.helpers({
    foo(x) { return x }
})
```

``` jade
h1(title=foo('bar')) #{foo (foo "bar") }
```

I understand this is still a limited change (not as good as the anonymous helpers would be) but it may be useful in the meantime, and should probably facilitate an eventual full merge. I checked the current tests and all seem to pass just fine, so there should be no harm done.

Just to clarify, this is all @dalgard 's work. I don't intend to maintain my fork (nor use it in my own projects), but rather help the main package to grow.
